### PR TITLE
Upgrade Kotlin to 1.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <java.version>1.7</java.version>
-    <kotlin.version>1.2.71</kotlin.version>
+    <kotlin.version>1.3.0</kotlin.version>
     <kotlin-metadata.version>1.4.0</kotlin-metadata.version>
     <dokka.version>0.9.17</dokka.version>
     <maven-assembly.version>3.1.0</maven-assembly.version>


### PR DESCRIPTION
When compiling an android project that depends on kotlin 1.3 and moshi 1.8 with codegen:

> w: Runtime JAR files in the classpath should have the same version. These files were found in the classpath:
>     .../.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib-jdk7/1.3.0/683e04a4e7f17437d7e1390480f312e122e42e9e/kotlin-stdlib-jdk7-1.3.0.jar (version 1.3)
>     .../.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-reflect/1.2.71/7512db3b3182753bd2e48ce8d345abbadc40fe6b/kotlin-reflect-1.2.71.jar (version 1.2)
>     .../.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib/1.3.0/a134b0cfe9bb44f98b0b3e889cda07923eea9428/kotlin-stdlib-1.3.0.jar (version 1.3)
>     .../.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib-common/1.3.0/84a2e0288dc17cd64d692eb1e5e0de8cd5ff0846/kotlin-stdlib-common-1.3.0.jar (version 1.3)
> w: Consider providing an explicit dependency on kotlin-reflect 1.3 to prevent strange errors
> 
